### PR TITLE
Slow playing computer vs computer option

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -31,6 +31,15 @@ class Board
     winner
   end
 
+  def next_player_mark
+    if count_for(Marks::X) >
+      count_for(Marks::O)
+      Marks::O
+    else
+      Marks::X
+    end
+  end
+
   def winner?
     winner_mark != nil
   end

--- a/lib/computer_player.rb
+++ b/lib/computer_player.rb
@@ -56,10 +56,6 @@ class ComputerPlayer
     end
   end
 
-  def switch_mark(mark)
-    mark = mark == X ? O : X
-  end
-
   def ready?
     true
   end
@@ -67,14 +63,14 @@ class ComputerPlayer
   private
 
   def score_favourable_for_computer?(current_mark, score, best_score)
-    if (computer_mark_is?(current_mark))
+    if (computer?(current_mark))
       score[0] > best_score
     else
       score[0] < best_score
     end
   end
 
-  def computer_mark_is?(current_mark)
+  def computer?(current_mark)
     current_mark == computer_mark
   end
 

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -12,11 +12,15 @@ class Game
   def play(players, board)
     current_player = players[Marks::X]
     until board.game_over? || !current_player(players, board).ready?
-      ui.draw_board(board)
-      board = current_player(players, board).make_move(board)
+      board = play_one_round(board, players)
     end
     end_game(board) if board.game_over?
     board
+  end
+
+  def play_one_round(board, players)
+      ui.draw_board(board)
+      current_player(players, board).make_move(board)
   end
 
   def current_player(players, board)

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -24,19 +24,10 @@ class Game
   end
 
   def current_player(players, board)
-    players[current_player_mark(board)]
+    players[board.next_player_mark]
   end
 
   private
-
-  def current_player_mark(board)
-    if board.count_for(Marks::X) >
-      board.count_for(Marks::O)
-      Marks::O
-    else
-      Marks::X
-    end
-  end
 
   def end_game(board)
     ui.draw_board(board)

--- a/lib/game_options_mapper.rb
+++ b/lib/game_options_mapper.rb
@@ -9,8 +9,6 @@ class GameOptionsMapper
       :ComputerVsHuman
     when 4
       :ComputerVsComputer
-    else
-      puts "invalid user choice"
     end
   end
 end

--- a/lib/game_options_mapper.rb
+++ b/lib/game_options_mapper.rb
@@ -1,4 +1,11 @@
 class GameOptionsMapper
+  GAME_OPTIONS = {1 => "Human vs Human",
+                  2 => "Human vs Computer",
+                  3 => "Computer vs Human"}
+  def game_options
+    GAME_OPTIONS
+  end
+
   def map(user_choice)
     case user_choice.to_i
     when  1

--- a/lib/game_options_mapper.rb
+++ b/lib/game_options_mapper.rb
@@ -1,0 +1,17 @@
+class GameOptionsMapper
+  def map(user_choice)
+    case user_choice.to_i
+    when  1
+      :HumanVsHuman
+    when 2
+      :HumanVsComputer
+    when 3
+      :ComputerVsHuman
+    when 4
+      :ComputerVsComputer
+    else
+      puts "invalid user choice"
+    end
+  end
+end
+

--- a/lib/game_runner.rb
+++ b/lib/game_runner.rb
@@ -1,13 +1,10 @@
 require 'game'
 require 'player_factory'
 require 'ui'
+require 'game_options_mapper'
 
 class GameRunner
   attr_reader :ui, :game, :player_factory
-
-  GAME_OPTIONS = {1 => "Human vs Human",
-                  2 => "Human vs Computer",
-                  3 => "Computer vs Human"}
 
   def initialize(ui, game, player_factory)
     @ui = ui
@@ -18,7 +15,7 @@ class GameRunner
   def start
     begin
       loop do
-        game_option = ui.menu(GAME_OPTIONS)
+        game_option = ui.menu(GameOptionsMapper.new.game_options)
         players = player_factory.create_console_players(game_option)
         game.play(players, Board.new)
         break unless ui.replay?

--- a/lib/marks.rb
+++ b/lib/marks.rb
@@ -1,4 +1,9 @@
 module Marks
   X = :X
   O = :O
+
+  def switch_mark(mark)
+    mark = mark == X ? O : X
+  end
+
 end

--- a/lib/marks.rb
+++ b/lib/marks.rb
@@ -3,7 +3,7 @@ module Marks
   O = :O
 
   def switch_mark(mark)
-    mark = mark == X ? O : X
+    mark == X ? O : X
   end
 
 end

--- a/lib/player_factory.rb
+++ b/lib/player_factory.rb
@@ -12,23 +12,25 @@ class PlayerFactory
   end
 
   def create_console_players(game_mode)
-    if game_mode == :HumanVsHuman
+    case game_mode
+    when :HumanVsHuman
       {X => HumanConsolePlayer.new(X, ui), O => HumanConsolePlayer.new(O, ui)}
-    elsif game_mode == :HumanVsComputer
+    when :HumanVsComputer
       {X => HumanConsolePlayer.new(X, ui), O => ComputerPlayer.new(O)}
-    elsif game_mode == :ComputerVsHuman
+    when :ComputerVsHuman
       {X => ComputerPlayer.new(X), O => HumanConsolePlayer.new(O, ui)}
     end
   end
 
   def create_web_players(game_mode)
-    if game_mode == :HumanVsHuman
+    case game_mode
+    when :HumanVsHuman
       {X => HumanWebPlayer.new(X), O => HumanWebPlayer.new(O)}
-    elsif game_mode == :HumanVsComputer
+    when :HumanVsComputer
       {X => HumanWebPlayer.new(X), O => ComputerPlayer.new(O)}
-    elsif game_mode == :ComputerVsHuman
+    when :ComputerVsHuman
       {X => ComputerPlayer.new(X), O => HumanWebPlayer.new(O)}
-    elsif game_mode == :ComputerVsComputer
+    when :ComputerVsComputer
       {X => ComputerPlayer.new(X), O => ComputerPlayer.new(O)}
     end
   end

--- a/lib/player_factory.rb
+++ b/lib/player_factory.rb
@@ -12,11 +12,11 @@ class PlayerFactory
   end
 
   def create_console_players(game_mode)
-    if game_mode == "1"
+    if game_mode == :HumanVsHuman
       {X => HumanConsolePlayer.new(X, ui), O => HumanConsolePlayer.new(O, ui)}
-    elsif game_mode == "2"
+    elsif game_mode == :HumanVsComputer
       {X => HumanConsolePlayer.new(X, ui), O => ComputerPlayer.new(O)}
-    elsif game_mode == "3"
+    elsif game_mode == :ComputerVsHuman
       {X => ComputerPlayer.new(X), O => HumanConsolePlayer.new(O, ui)}
     end
   end

--- a/lib/player_factory.rb
+++ b/lib/player_factory.rb
@@ -22,13 +22,13 @@ class PlayerFactory
   end
 
   def create_web_players(game_mode)
-    if game_mode == "1"
+    if game_mode == :HumanVsHuman
       {X => HumanWebPlayer.new(X), O => HumanWebPlayer.new(O)}
-    elsif game_mode == "2"
+    elsif game_mode == :HumanVsComputer
       {X => HumanWebPlayer.new(X), O => ComputerPlayer.new(O)}
-    elsif game_mode == "3"
+    elsif game_mode == :ComputerVsHuman
       {X => ComputerPlayer.new(X), O => HumanWebPlayer.new(O)}
-    elsif game_mode == "4"
+    elsif game_mode == :ComputerVsComputer
       {X => ComputerPlayer.new(X), O => ComputerPlayer.new(O)}
     end
   end

--- a/lib/player_factory.rb
+++ b/lib/player_factory.rb
@@ -28,6 +28,8 @@ class PlayerFactory
       {X => HumanWebPlayer.new(X), O => ComputerPlayer.new(O)}
     elsif game_mode == "3"
       {X => ComputerPlayer.new(X), O => HumanWebPlayer.new(O)}
+    elsif game_mode == "4"
+      {X => ComputerPlayer.new(X), O => ComputerPlayer.new(O)}
     end
   end
 end

--- a/lib/ui.rb
+++ b/lib/ui.rb
@@ -24,8 +24,9 @@ class Ui
 
   def get_game_mode(game_options)
     mode = input.gets.chomp
-    if (1..game_options.length).include? mode.to_i || mode == "q"
-      GameOptionsMapper.new.map(mode)
+    mapper = GameOptionsMapper.new
+    if (mapper.game_options.key?(mode.to_i))
+      mapper.map(mode)
     else
       game_mode_selection_error
       menu(game_options)

--- a/lib/ui.rb
+++ b/lib/ui.rb
@@ -1,4 +1,5 @@
 require 'marks'
+require 'game_options_mapper'
 
 class Ui
   include Marks
@@ -24,7 +25,7 @@ class Ui
   def get_game_mode(game_options)
     mode = input.gets.chomp
     if (1..game_options.length).include? mode.to_i || mode == "q"
-      mode
+      GameOptionsMapper.new.map(mode)
     else
       game_mode_selection_error
       menu(game_options)

--- a/lib/views/game.erb
+++ b/lib/views/game.erb
@@ -1,3 +1,6 @@
+<% if @game_option == "4" && !@board.game_over? %>
+  <meta http-equiv="refresh" content="1">
+<% end %>
 <div class='board'>
   <% @board.rows.each do |row| %>
     <div class='row'>

--- a/lib/views/game.erb
+++ b/lib/views/game.erb
@@ -1,4 +1,4 @@
-<% if @game_option == "4" && !@board.game_over? %>
+<% if @game_option == :ComputerVsComputer && !@board.game_over? %>
   <meta http-equiv="refresh" content="1">
 <% end %>
 <div class='board'>

--- a/lib/views/game.erb
+++ b/lib/views/game.erb
@@ -1,7 +1,7 @@
 <% if @game_option == :ComputerVsComputer && !@board.game_over? %>
   <meta http-equiv="refresh" content="1">
 <% end %>
-<div class='board'>
+<div class='board <% if @game_option == :ComputerVsComputer || @board.game_over?%>disabled<% end %>'>
   <% @board.rows.each do |row| %>
     <div class='row'>
       <div class='wrapper'>

--- a/lib/views/menu.erb
+++ b/lib/views/menu.erb
@@ -12,5 +12,9 @@
     <input id="computer-vs-human" class="option-choice" type="radio" name="option" value="3">
     <label for="computer-vs-human">Computer vs Human</label>
   </p>
+  <p>
+    <input id="computer-vs-computer" class="option-choice" type="radio" name="option" value="4">
+    <label for="computer-vs-computer">Computer vs Computer</label>
+  </p>
   <button type="submit">Submit</button>
 </form>

--- a/lib/views/menu.erb
+++ b/lib/views/menu.erb
@@ -16,5 +16,5 @@
     <input id="computer-vs-computer" class="option-choice" type="radio" name="option" value="4">
     <label for="computer-vs-computer">Computer vs Computer</label>
   </p>
-  <button type="submit">Submit</button>
+  <button type="submit">Start game</button>
 </form>

--- a/lib/views/styles.scss
+++ b/lib/views/styles.scss
@@ -30,6 +30,13 @@ h1 {
   margin: 0 auto 40px;
 }
 
+.board.disabled {
+  a {
+    pointer-events: none;
+    cursor: default;
+  }
+}
+
 .row {
   border-bottom: 1px solid black;
   display: -webkit-box;

--- a/lib/views/styles.scss
+++ b/lib/views/styles.scss
@@ -99,7 +99,7 @@ h2.menu {
 
 .game-options-form {
   p {
-    width: 260px;
+    width: 290px;
     margin: 20px auto;
     text-align: center;
     background-color: #e5e0e0;

--- a/lib/web_controller.rb
+++ b/lib/web_controller.rb
@@ -37,7 +37,7 @@ class WebController < Sinatra::Base
 
   def set_template_variables
     @game_option = session["game_option"]
-    @board = Board.new(session['board_rows'].flatten)
+    @board = current_board
     @winner_mark = @board.winner_mark
     @draw = @board.draw?
   end
@@ -45,7 +45,6 @@ class WebController < Sinatra::Base
   get '/move' do
     players = PlayerFactory.new(WebUi.new).create_web_players(session['game_option'])
     game = Game.new(WebUi.new)
-    current_board = Board.new(session['board_rows'].flatten)
     player = game.current_player(players, current_board)
     player.add_move(params[:move])
     session['board_rows'] = game.play(players, current_board).rows
@@ -65,10 +64,9 @@ class WebController < Sinatra::Base
   end
 
   def play_computer_vs_computer_game
-    unless Board.new(session['board_rows'].flatten).game_over?
+    unless current_board.game_over?
       game = Game.new(WebUi.new)
       players = PlayerFactory.new(WebUi.new).create_web_players(session['game_option'])
-      current_board = Board.new(session['board_rows'].flatten)
       session['board_rows'] = game.current_player(players, current_board).make_move(current_board).rows
       sleep 1
     end
@@ -77,8 +75,12 @@ class WebController < Sinatra::Base
   def play_first_computer_move
     if first_computer_move
       players = PlayerFactory.new(WebUi.new).create_web_players(session['game_option'])
-      session['board_rows'] = Game.new(WebUi.new).play(players, Board.new).rows
+      session['board_rows'] = Game.new(WebUi.new).play(players, current_board).rows
       session['first_move'] = false
     end
+  end
+
+  def current_board
+    Board.new(session['board_rows'].flatten)
   end
 end

--- a/lib/web_controller.rb
+++ b/lib/web_controller.rb
@@ -43,10 +43,8 @@ class WebController < Sinatra::Base
   end
 
   get '/move' do
-    players = PlayerFactory.new(WebUi.new).create_web_players(session['game_option'])
-    game = Game.new(WebUi.new)
-    player = game.current_player(players, current_board)
-    player.add_move(params[:move])
+    players = current_game_players
+    game.current_player(players, current_board).add_move(params[:move])
     session['board_rows'] = game.play(players, current_board).rows
     redirect '/game'
   end
@@ -65,22 +63,29 @@ class WebController < Sinatra::Base
 
   def play_computer_vs_computer_game
     unless current_board.game_over?
-      game = Game.new(WebUi.new)
-      players = PlayerFactory.new(WebUi.new).create_web_players(session['game_option'])
-      session['board_rows'] = game.current_player(players, current_board).make_move(current_board).rows
+      session['board_rows'] =
+        game.current_player(current_game_players, current_board).make_move(current_board).rows
       sleep 1
     end
   end
 
   def play_first_computer_move
     if first_computer_move
-      players = PlayerFactory.new(WebUi.new).create_web_players(session['game_option'])
-      session['board_rows'] = Game.new(WebUi.new).play(players, current_board).rows
+      current_game_players
+      session['board_rows'] = game.play(current_game_players, current_board).rows
       session['first_move'] = false
     end
   end
 
+  def current_game_players
+      PlayerFactory.new(WebUi.new).create_web_players(session['game_option'])
+  end
+
   def current_board
     Board.new(session['board_rows'].flatten)
+  end
+
+  def game
+    Game.new(WebUi.new)
   end
 end

--- a/lib/web_controller.rb
+++ b/lib/web_controller.rb
@@ -55,6 +55,6 @@ class WebController < Sinatra::Base
   end
 
   def first_computer_move
-    session['game_option'] == "3" && session['first_move'] == true
+    (session['game_option'] == "3" || session['game_option'] == "4") && session['first_move'] == true
   end
 end

--- a/spec/computer_player_spec.rb
+++ b/spec/computer_player_spec.rb
@@ -76,7 +76,7 @@ describe ComputerPlayer do
     expect(player.ready?).to be true
   end
 
-  it "makes the first move in under 2 second" do
+  it "makes the first move in under 2 seconds", slow: true do
     start_time = Time.now
     player.make_move(Board.new)
     end_time = Time.now

--- a/spec/game_options_mapper_spec.rb
+++ b/spec/game_options_mapper_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'game_options_mapper'
+
+describe GameOptionsMapper do
+  let(:game_options_mapper) {GameOptionsMapper.new}
+
+  it "maps the option 1 to HvH" do
+    expect(game_options_mapper.map("1")).to eq :HumanVsHuman
+  end
+
+  it "maps the option 2 to HvC" do
+    expect(game_options_mapper.map("2")).to eq :HumanVsComputer
+  end
+
+  it "maps the option 3 to CvH" do
+    expect(game_options_mapper.map("3")).to eq :ComputerVsHuman
+  end
+
+  it "maps the option 4 to CvC" do
+    expect(game_options_mapper.map("4")).to eq :ComputerVsComputer
+  end
+end

--- a/spec/game_runner_spec.rb
+++ b/spec/game_runner_spec.rb
@@ -19,14 +19,14 @@ describe GameRunner do
   end
 
   it "catches exception if a user interrupts with ctrl + c" do
-    disruptive_ui = DisruptiveUi.new
+    disruptive_ui = InterruptingUi.new
     player_factory = PlayerFactory.new(disruptive_ui)
     game_runner = GameRunner.new(disruptive_ui, game_spy, player_factory)
     game_runner.start
     expect(disruptive_ui.displayed_interruption_message?).to be true
   end
 
-  class DisruptiveUi
+  class InterruptingUi
     def initialize
       @says_goodbye = false
     end

--- a/spec/player_factory_spec.rb
+++ b/spec/player_factory_spec.rb
@@ -12,6 +12,7 @@ describe PlayerFactory do
   HUMAN_VS_HUMAN = "1"
   HUMAN_VS_COMPUTER = "2"
   COMPUTER_VS_HUMAN = "3"
+  COMPUTER_VS_COMPUTER = "4"
 
   it "creates a computer player and a human console player" do
     factory = PlayerFactory.new(ui)
@@ -47,5 +48,11 @@ describe PlayerFactory do
     factory = PlayerFactory.new(ui)
     expect(factory.create_web_players(COMPUTER_VS_HUMAN)[Marks::X]).to be_a ComputerPlayer
     expect(factory.create_web_players(COMPUTER_VS_HUMAN)[Marks::O]).to be_a HumanWebPlayer
+  end
+
+  it "creates two computer players for the web game" do
+    factory = PlayerFactory.new(ui)
+    expect(factory.create_web_players(COMPUTER_VS_COMPUTER)[Marks::X]).to be_a ComputerPlayer
+    expect(factory.create_web_players(COMPUTER_VS_COMPUTER)[Marks::O]).to be_a ComputerPlayer
   end
 end

--- a/spec/player_factory_spec.rb
+++ b/spec/player_factory_spec.rb
@@ -9,11 +9,6 @@ describe PlayerFactory do
   include Marks
   let (:ui) {Ui.new(nil, nil)}
 
-  HUMAN_VS_HUMAN = "1"
-  HUMAN_VS_COMPUTER = "2"
-  COMPUTER_VS_HUMAN = "3"
-  COMPUTER_VS_COMPUTER = "4"
-
   it "creates a computer player and a human console player" do
     factory = PlayerFactory.new(ui)
     expect(factory.create_console_players(:ComputerVsHuman)[Marks::X]).to be_a ComputerPlayer

--- a/spec/player_factory_spec.rb
+++ b/spec/player_factory_spec.rb
@@ -34,25 +34,25 @@ describe PlayerFactory do
 
   it "creates two human web players" do
     factory = PlayerFactory.new(ui)
-    expect(factory.create_web_players(HUMAN_VS_HUMAN)[Marks::X]).to be_a HumanWebPlayer
-    expect(factory.create_web_players(HUMAN_VS_HUMAN)[Marks::O]).to be_a HumanWebPlayer
+    expect(factory.create_web_players(:HumanVsHuman)[Marks::X]).to be_a HumanWebPlayer
+    expect(factory.create_web_players(:HumanVsHuman)[Marks::O]).to be_a HumanWebPlayer
   end
 
   it "creates a human web player and a computer player" do
     factory = PlayerFactory.new(ui)
-    expect(factory.create_web_players(HUMAN_VS_COMPUTER)[Marks::X]).to be_a HumanWebPlayer
-    expect(factory.create_web_players(HUMAN_VS_COMPUTER)[Marks::O]).to be_a ComputerPlayer
+    expect(factory.create_web_players(:HumanVsComputer)[Marks::X]).to be_a HumanWebPlayer
+    expect(factory.create_web_players(:HumanVsComputer)[Marks::O]).to be_a ComputerPlayer
   end
 
   it "creates a human web player and a computer player" do
     factory = PlayerFactory.new(ui)
-    expect(factory.create_web_players(COMPUTER_VS_HUMAN)[Marks::X]).to be_a ComputerPlayer
-    expect(factory.create_web_players(COMPUTER_VS_HUMAN)[Marks::O]).to be_a HumanWebPlayer
+    expect(factory.create_web_players(:ComputerVsHuman)[Marks::X]).to be_a ComputerPlayer
+    expect(factory.create_web_players(:ComputerVsHuman)[Marks::O]).to be_a HumanWebPlayer
   end
 
   it "creates two computer players for the web game" do
     factory = PlayerFactory.new(ui)
-    expect(factory.create_web_players(COMPUTER_VS_COMPUTER)[Marks::X]).to be_a ComputerPlayer
-    expect(factory.create_web_players(COMPUTER_VS_COMPUTER)[Marks::O]).to be_a ComputerPlayer
+    expect(factory.create_web_players(:ComputerVsComputer)[Marks::X]).to be_a ComputerPlayer
+    expect(factory.create_web_players(:ComputerVsComputer)[Marks::O]).to be_a ComputerPlayer
   end
 end

--- a/spec/player_factory_spec.rb
+++ b/spec/player_factory_spec.rb
@@ -16,20 +16,20 @@ describe PlayerFactory do
 
   it "creates a computer player and a human console player" do
     factory = PlayerFactory.new(ui)
-    expect(factory.create_console_players(COMPUTER_VS_HUMAN)[Marks::X]).to be_a ComputerPlayer
-    expect(factory.create_console_players(COMPUTER_VS_HUMAN)[Marks::O]).to be_a HumanConsolePlayer
+    expect(factory.create_console_players(:ComputerVsHuman)[Marks::X]).to be_a ComputerPlayer
+    expect(factory.create_console_players(:ComputerVsHuman)[Marks::O]).to be_a HumanConsolePlayer
   end
 
   it "creates a human console player and a computer player" do
     factory = PlayerFactory.new(ui)
-    expect(factory.create_console_players(HUMAN_VS_COMPUTER)[Marks::X]).to be_a HumanConsolePlayer
-    expect(factory.create_console_players(HUMAN_VS_COMPUTER)[Marks::O]).to be_a ComputerPlayer
+    expect(factory.create_console_players(:HumanVsComputer)[Marks::X]).to be_a HumanConsolePlayer
+    expect(factory.create_console_players(:HumanVsComputer)[Marks::O]).to be_a ComputerPlayer
   end
 
   it "creates two human console players" do
     factory = PlayerFactory.new(ui)
-    expect(factory.create_console_players(HUMAN_VS_HUMAN)[Marks::X]).to be_a HumanConsolePlayer
-    expect(factory.create_console_players(HUMAN_VS_HUMAN)[Marks::O]).to be_a HumanConsolePlayer
+    expect(factory.create_console_players(:HumanVsHuman)[Marks::X]).to be_a HumanConsolePlayer
+    expect(factory.create_console_players(:HumanVsHuman)[Marks::O]).to be_a HumanConsolePlayer
    end
 
   it "creates two human web players" do

--- a/spec/ui_spec.rb
+++ b/spec/ui_spec.rb
@@ -29,16 +29,16 @@ describe Ui do
 
   it "gets the game mode" do
     ui = Ui.new(StringIO.new("2"), output)
-    expect(ui.menu(GAME_OPTIONS)).to eq("2")
+    expect(ui.menu(GAME_OPTIONS)).to eq(:HumanVsComputer)
   end
 
   it "displays error message and menu options on bad user input" do
     ERROR_MESSAGE = "Please select a valid game mode!"
-    allow(ui.input).to receive(:gets).and_return("bad", "3")
+    VALID_OPTION = "3"
+    allow(ui.input).to receive(:gets).and_return("bad", VALID_OPTION)
     ui.get_game_mode(GAME_OPTIONS)
     expect(output.string).to include(ERROR_MESSAGE)
   end
-
 
   it "asks user for position" do
     output = StringIO.new

--- a/spec/web_controller_spec.rb
+++ b/spec/web_controller_spec.rb
@@ -32,17 +32,17 @@ describe WebController do
 
   it "adds game options choice from params into session" do
     post '/menu', 'option' => '1'
-    expect(last_request.env['rack.session']['game_option']).to eql('1')
+    expect(last_request.env['rack.session']['game_option']).to eql(:HumanVsHuman)
   end
 
   it "displays empty board on game route template for a Human vs Human game" do
-    get '/game', {}, {'rack.session' => {'game_option' => '1'}}
+    get '/game', {}, {'rack.session' => {'game_option' => :HumanVsHuman}}
     expect(last_response).to be_ok
     expect(last_response.body).not_to include "class='cell full'"
   end
 
   it "gets and displays computer's first move for Computer vs Human game" do
-    get '/game', {}, {'rack.session' => {'game_option' => '3', 'first_move' => true}}
+    get '/game', {}, {'rack.session' => {'game_option' => :ComputerVsHuman, 'first_move' => true}}
     rows = last_request.env['rack.session']['board_rows']
     expect(rows.flatten).to include :X
     expect(Board.new(rows.flatten).available_positions.length).to be 8
@@ -50,14 +50,14 @@ describe WebController do
 
   it "redirects a get request to /move to game" do
     rows = [Marks::X, Marks::X, Marks::X, 3, 4, 5, 6, 7, 8]
-    get '/move', {}, {'rack.session' => {'game_option' => '1', 'board_rows' => rows}}
+    get '/move', {}, {'rack.session' => {'game_option' => :HumanVsHuman, 'board_rows' => rows}}
     expect(last_response).to be_redirect
     expect(last_response.location).to include '/game'
   end
 
   it "updates board with move from params" do
     board_rows = [0, Marks::X, Marks::X, 3, 4, 5, 6, 7, 8]
-    get '/move?move=8', {}, {'rack.session' => {'game_option' => '1', 'board_rows' => board_rows}}
+    get '/move?move=8', {}, {'rack.session' => {'game_option' => :HumanVsHuman, 'board_rows' => board_rows}}
     board_rows = last_request.env['rack.session']['board_rows']
     expect(board_rows).to eql([[0, Marks::X, Marks::X], [3, 4, 5], [6, 7, Marks::O]])
   end
@@ -75,7 +75,7 @@ describe WebController do
   end
 
   it "resets the game option when the root route is requested" do
-    get '/game', {}, {'rack.session' => {'game_option' => '2'}}
+    get '/game', {}, {'rack.session' => {'game_option' => :HumanVsComputer}}
     get '/'
     expect(last_request.env['rack.session']['game_option']).to eql(nil)
   end

--- a/spec/web_controller_spec.rb
+++ b/spec/web_controller_spec.rb
@@ -21,12 +21,12 @@ describe WebController do
   end
 
   it "clears board on post request to /menu" do
-    post '/menu', {}, {'rack.session' => {'board_rows' => ["grid"]}}
+    post '/menu', {'option' => '1'}, {'rack.session' => {'board_rows' => ['grid']}}
     expect(last_request.env['rack.session']['board_rows']).to eql(nil)
   end
 
   it "redirects to game route after a post request to /menu" do
-    post '/menu'
+    post '/menu', 'option' => '1'
     expect(last_response).to be_redirect
   end
 
@@ -43,6 +43,13 @@ describe WebController do
 
   it "gets and displays computer's first move for Computer vs Human game" do
     get '/game', {}, {'rack.session' => {'game_option' => :ComputerVsHuman, 'first_move' => true}}
+    rows = last_request.env['rack.session']['board_rows']
+    expect(rows.flatten).to include :X
+    expect(Board.new(rows.flatten).available_positions.length).to be 8
+  end
+
+  it "plays first move of Computer vs Computer game" do
+    get '/game', {}, {'rack.session' => {'game_option' => :ComputerVsComputer}}
     rows = last_request.env['rack.session']['board_rows']
     expect(rows.flatten).to include :X
     expect(Board.new(rows.flatten).available_positions.length).to be 8

--- a/spec/web_controller_spec.rb
+++ b/spec/web_controller_spec.rb
@@ -9,6 +9,7 @@ require 'marks'
 describe WebController do
   include Marks
   include Rack::Test::Methods
+  HUMAN_VS_HUMAN = '1'
 
   def app
     WebController.new
@@ -21,17 +22,17 @@ describe WebController do
   end
 
   it "clears board on post request to /menu" do
-    post '/menu', {'option' => '1'}, {'rack.session' => {'board_rows' => ['grid']}}
+    post '/menu', {'option' => HUMAN_VS_HUMAN}, {'rack.session' => {'board_rows' => ['grid']}}
     expect(last_request.env['rack.session']['board_rows']).to eql(nil)
   end
 
   it "redirects to game route after a post request to /menu" do
-    post '/menu', 'option' => '1'
+    post '/menu', 'option' => HUMAN_VS_HUMAN
     expect(last_response).to be_redirect
   end
 
   it "adds game options choice from params into session" do
-    post '/menu', 'option' => '1'
+    post '/menu', 'option' => HUMAN_VS_HUMAN
     expect(last_request.env['rack.session']['game_option']).to eql(:HumanVsHuman)
   end
 
@@ -72,7 +73,7 @@ describe WebController do
   it "displays game over message with winning mark when winner is available" do
     ui = WebUi.new
     rows = [Marks::X, Marks::X, Marks::X, 3, 4, 5, 6, 7, 8]
-    get '/game', {}, {'rack.session' => {'board_rows' => rows, 'game_option' => '2'}}
+    get '/game', {}, {'rack.session' => {'board_rows' => rows, 'game_option' => :HumanVsComputer}}
     expect(last_response.body).to include('Game over! Winner is X.')
   end
 

--- a/spec/web_controller_spec.rb
+++ b/spec/web_controller_spec.rb
@@ -91,4 +91,16 @@ describe WebController do
     get '/styles.css'
     expect(last_response.body).to include('box-sizing: border-box;')
   end
+
+  it "disables board when game is over" do
+    board_rows = [Marks::X, Marks::X, Marks::X, Marks::O, Marks::O, 5, 6, 7, 8]
+    get '/game', {}, {'rack.session' => {'game_option' => :HumanVsComputer, 'board_rows' => board_rows}}
+    expect(last_response.body).to include("class='board disabled'")
+  end
+
+  it "disables board during computer vs computer game", slow: true do
+    board_rows = [Marks::X, 1, Marks::X, Marks::O, Marks::O, Marks::X, Marks::O, 7, 8]
+    get '/game', {}, {'rack.session' => {'game_option' => :ComputerVsComputer, 'board_rows' => board_rows}}
+    expect(last_response.body).to include("class='board disabled'")
+  end
 end

--- a/spec/web_controller_spec.rb
+++ b/spec/web_controller_spec.rb
@@ -41,14 +41,14 @@ describe WebController do
     expect(last_response.body).not_to include "class='cell full'"
   end
 
-  it "gets and displays computer's first move for Computer vs Human game" do
+  it "gets and displays computer's first move for Computer vs Human game", slow: true do
     get '/game', {}, {'rack.session' => {'game_option' => :ComputerVsHuman, 'first_move' => true}}
     rows = last_request.env['rack.session']['board_rows']
     expect(rows.flatten).to include :X
     expect(Board.new(rows.flatten).available_positions.length).to be 8
   end
 
-  it "plays first move of Computer vs Computer game" do
+  it "plays first move of Computer vs Computer game", slow: true do
     get '/game', {}, {'rack.session' => {'game_option' => :ComputerVsComputer}}
     rows = last_request.env['rack.session']['board_rows']
     expect(rows.flatten).to include :X

--- a/spec/web_controller_spec.rb
+++ b/spec/web_controller_spec.rb
@@ -74,6 +74,12 @@ describe WebController do
     expect(last_response.body).to include('Something went wrong')
   end
 
+  it "resets the game option when the root route is requested" do
+    get '/game', {}, {'rack.session' => {'game_option' => '2'}}
+    get '/'
+    expect(last_request.env['rack.session']['game_option']).to eql(nil)
+  end
+
   it "displays styling when the route /styles.css is requested" do
     get '/styles.css'
     expect(last_response.body).to include('box-sizing: border-box;')


### PR DESCRIPTION
@jsuchy @felipesere

This PR implements the following:
- a slow playing computer vs computer game option
- empty board cell links are disabled when computer vs computer game is playing and when game is over
- reducing magic numbers by implementing a class that maps numbers to symbols for the game options
- a method name change and a method move to a different class as per Felipe's suggestion in a previous PR
