### PR TITLE
Clicks on empty cells now create POST requests

### DIFF
--- a/lib/views/game.erb
+++ b/lib/views/game.erb
@@ -6,21 +6,30 @@
     <div class='row'>
       <div class='wrapper'>
         <% if @board.available_positions.include? row[0] %>
-          <a class='cell' href="/move?move=<%= row[0] %>"><div class='empty'>&nbsp;</div></a>
+          <form class="cell-form" method="post" action="/move">
+            <input class="hidden" type="hidden" name="position" value=<%= row[0].to_s %>>
+            <button class='cell' type="submit"><div class='empty'>&nbsp;</div></button>
+          </form>
         <% else %>
           <div class='cell full'><%= row[0] %></div>
         <% end %>
       </div>
       <div class='wrapper'>
         <% if @board.available_positions.include? row[1] %>
-          <a class='cell' href="/move?move=<%= row[1] %>"><div class='empty'>&nbsp;</div></a>
+          <form class="cell-form" method="post" action="/move">
+            <input class="hidden" type="hidden" name="position" value=<%= row[1].to_s %>>
+            <button class='cell' type="submit"><div class='empty'>&nbsp;</div></button>
+          </form>
         <% else %>
           <div class='cell full'><%= row[1] %></div>
         <% end %>
       </div>
       <div class='wrapper'>
         <% if @board.available_positions.include? row[2] %>
-          <a class='cell' href="/move?move=<%= row[2] %>"><div class='empty'>&nbsp;</div></a>
+          <form class="cell-form" method ="post" action="/move">
+            <input class="hidden" type="hidden" name="position" value=<%= row[2].to_s %>>
+            <button class='cell' type="submit"><div class='empty'>&nbsp;</div></button>
+          </form>
         <% else %>
           <div class='cell full'><%= row[2] %></div>
         <% end %>

--- a/lib/views/styles.scss
+++ b/lib/views/styles.scss
@@ -17,11 +17,16 @@ body {
   font-size: 18px;
   margin: 0 0 35px;
   text-align: center;
+  padding: 10px;
 }
 
 h1 {
   font-size: 3em;
   margin-bottom: 70px;
+}
+
+h2 {
+  font-size: 1.5em;
 }
 
 .board {
@@ -31,7 +36,7 @@ h1 {
 }
 
 .board.disabled {
-  a {
+  button {
     pointer-events: none;
     cursor: default;
   }
@@ -67,17 +72,14 @@ h1 {
 
 .cell {
   text-decoration: none;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
+  border: none;
 }
 
 .empty {
-  margin: 10px auto 0;
+  margin: 2px auto 0;
   background-color: #e5e0e0;
   height: 120px;
-  max-width: 120px;
+  width: 120px;
   cursor: pointer;
   transition: .6s;
 }
@@ -88,6 +90,11 @@ h1 {
 
 .full {
   font-size: 5.5em;
+  margin: 0 auto;
+}
+
+.cell-form {
+  margin: 0 auto;
 }
 
 .game-end-message {
@@ -150,9 +157,37 @@ button, .play-again, .choose-game-option {
   font-size: 1em;
   text-decoration: none;
   vertical-align: middle;
+  &:focus {
+    outline:0;
+  }
 }
 
 .play-again {
   font-size: .8em;
 }
 
+@media only screen and (max-width:520px) {
+  h2 {
+    font-size: 1.2em;
+  }
+
+  .empty {
+    height: 90px;
+    width: 90px;
+    margin: 0;
+  }
+
+  .wrapper {
+    height: 120px;
+    width: 120px;
+  }
+
+  .cell {
+    width: 90px;
+    padding: 15px 0px;
+  }
+
+  .full {
+    margin: -15px auto;
+  }
+}

--- a/lib/web_controller.rb
+++ b/lib/web_controller.rb
@@ -42,9 +42,9 @@ class WebController < Sinatra::Base
     @draw = @board.draw?
   end
 
-  get '/move' do
+  post '/move' do
     players = current_game_players
-    game.current_player(players, current_board).add_move(params[:move])
+    game.current_player(players, current_board).add_move(params[:position])
     session['board_rows'] = game.play(players, current_board).rows
     redirect '/game'
   end

--- a/spec/web_controller_spec.rb
+++ b/spec/web_controller_spec.rb
@@ -56,16 +56,16 @@ describe WebController do
     expect(Board.new(rows.flatten).available_positions.length).to be 8
   end
 
-  it "redirects a get request to /move to game" do
+  it "redirects a post request to /move to game" do
     rows = [Marks::X, Marks::X, Marks::X, 3, 4, 5, 6, 7, 8]
-    get '/move', {}, {'rack.session' => {'game_option' => :HumanVsHuman, 'board_rows' => rows}}
+    post '/move', {'position' => '1'}, {'rack.session' => {'game_option' => :HumanVsHuman, 'board_rows' => rows}}
     expect(last_response).to be_redirect
     expect(last_response.location).to include '/game'
   end
 
   it "updates board with move from params" do
     board_rows = [0, Marks::X, Marks::X, 3, 4, 5, 6, 7, 8]
-    get '/move?move=8', {}, {'rack.session' => {'game_option' => :HumanVsHuman, 'board_rows' => board_rows}}
+    post '/move', {'position' => '8'}, {'rack.session' => {'game_option' => :HumanVsHuman, 'board_rows' => board_rows}}
     board_rows = last_request.env['rack.session']['board_rows']
     expect(board_rows).to eql([[0, Marks::X, Marks::X], [3, 4, 5], [6, 7, Marks::O]])
   end


### PR DESCRIPTION
@jsuchy @felipesere

Empty cells are now buttons with POST requests. I previously used links with GET requests.

This wasn't explicitly part of my stories but Jim mentioned in my last IPM that I shouldn't be using GET requests here. GET requests should be used to read data but a click on a cell creates a new resource (the user's choice of a position) so it is better to use a POST request.
